### PR TITLE
fix: make elastic deformation direction-aware

### DIFF
--- a/core/src/main/java/com/qmdeve/liquidglass/util/LiquidTracker.java
+++ b/core/src/main/java/com/qmdeve/liquidglass/util/LiquidTracker.java
@@ -124,11 +124,29 @@ public class LiquidTracker {
         velocityTracker.computeCurrentVelocity(1);
         float velocityX = velocityTracker.getXVelocity();
         float velocityY = velocityTracker.getYVelocity();
-        float velocity = (float)Math.sqrt(velocityX * velocityX + velocityY * velocityY);
+
+        // Calculate deformation separately for X and Y directions
+        // Stretch along movement direction, compress perpendicular to it
+        float absVx = Math.abs(velocityX);
+        float absVy = Math.abs(velocityY);
+
+        // Deformation intensity factor, adjust this value to control the degree of deformation
+        float stretchFactor = 0.5f;
+
+        float scaleX, scaleY;
+        if (absVx > absVy) {
+            // Horizontal movement dominant: stretch X axis, compress Y axis
+            scaleX = 1f + absVx * stretchFactor;
+            scaleY = 1f - absVx * stretchFactor * 0.5f;
+        } else {
+            // Vertical movement dominant: stretch Y axis, compress X axis
+            scaleX = 1f - absVy * stretchFactor * 0.5f;
+            scaleY = 1f + absVy * stretchFactor;
+        }
 
         return new float[] {
-                Math.clamp(1f + velocity * 0.5f, 0.6f, 1.4f),
-                Math.clamp(1f - velocity * 0.5f, 0.6f, 1.4f)
+                Math.clamp(scaleX, 0.6f, 1.4f),
+                Math.clamp(scaleY, 0.6f, 1.4f)
         };
     }
 


### PR DESCRIPTION
## Summary
Fix the elastic deformation effect to follow the drag direction.

## Changes
- Previously, deformation was always X-stretch/Y-compress regardless of movement direction
- Now stretches along the dominant movement axis (horizontal or vertical)
  - Horizontal drag: X-axis stretches, Y-axis compresses
  - Vertical drag: Y-axis stretches, X-axis compresses
- Added `stretchFactor` parameter for easy customization

## Before
Dragging in any direction always caused horizontal stretching.

## After
Dragging now stretches in the direction of movement, creating a more natural "liquid" feel.