### PR TITLE
修复部分设备低分辨率下长条玻璃出现中线的问题

### DIFF
--- a/core/src/main/res/raw/liquidglass_effect.agsl
+++ b/core/src/main/res/raw/liquidglass_effect.agsl
@@ -68,10 +68,31 @@ float sdRoundedRect(float2 coord, float2 halfSize, float radius) {
     return outside + inside;
 }
 
+float safeSign(float value) {
+    return value < 0.0 ? -1.0 : 1.0;
+}
+
+float2 safeNormalize(float2 value, float2 fallback) {
+    float len = length(value);
+    if (len > 0.001) {
+        return value / len;
+    }
+    return fallback;
+}
+
 float2 gradSdRoundedRect(float2 coord, float2 halfSize, float radius) {
     float2 cornerCoord = abs(coord) - (halfSize - float2(radius));
     if (cornerCoord.x >= 0.0 || cornerCoord.y >= 0.0) {
-        return sign(coord) * normalize(max(cornerCoord, 0.0));
+        float2 outside = max(cornerCoord, 0.0);
+        float outsideLength = length(outside);
+        if (outsideLength > 0.001) {
+            return sign(coord) * (outside / outsideLength);
+        }
+        float useX = step(cornerCoord.y, cornerCoord.x);
+        return float2(
+            useX * safeSign(coord.x),
+            (1.0 - useX) * safeSign(coord.y)
+        );
     } else {
         float gradX = step(cornerCoord.y, cornerCoord.x);
         return sign(coord) * float2(gradX, 1.0 - gradX);
@@ -113,7 +134,9 @@ half4 main(float2 coord) {
     float smoothRadius = max(radius * 1.5, 30.0);
     float gradRadius = min(smoothRadius, min(halfSize.x, halfSize.y));
 
-    float2 grad = normalize(gradSdRoundedRect(centeredCoord, halfSize, gradRadius) + depthEffect * normalize(centeredCoord));
+    float2 shapeGrad = gradSdRoundedRect(centeredCoord, halfSize, gradRadius);
+    float2 depthGrad = safeNormalize(centeredCoord, shapeGrad);
+    float2 grad = safeNormalize(shapeGrad + depthEffect * depthGrad, shapeGrad);
 
     float2 refractedCoord = coord + d * grad;
     float dispersionIntensity = chromaticAberration * ((centeredCoord.x * centeredCoord.y) / (halfSize.x * halfSize.y));


### PR DESCRIPTION
在 iQOO 15 和小米 15 Pro 上发现，设备降低屏幕分辨率后，长条 pill 形态的 LiquidGlass 中间会出现一条常驻线，圆形按钮和左右圆角区域正常。

原因是长条 pill 中间有些点算出来的方向向量会接近 0，后面再做归一化时，不同设备和分辨率下会出现不稳定采样，所以看起来就像中间多了一条线。

这次给 shader 里的向量归一化加了兜底，避免这种情况下继续用不稳定的方向。

已经在实际项目中验证，低分辨率下原本稳定出现的中线现在消失了。